### PR TITLE
[#39] added special request header for identity of request from jira-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-helper",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "jira-helper: Elements for vizualizations, tetris-planing with sprints, button template, swimline-viz",
   "repository": "https://github.com/TinkoffCreditSystems/jira-helper.git",
   "license": "ISC",

--- a/src/README.md
+++ b/src/README.md
@@ -178,7 +178,7 @@ SLA показывает значение в днях.
 ## Identity request from Jira-HelpeIdentify request from Jira-Helper
 
 Your administrators of JIRA can identify requests from jira-helper by the special request header
-"chrome-plugin: jira-helper/{version}".
+"browser-plugin: jira-helper/{version}".
 
 ![jira-helper-reques](https://raw.githubusercontent.com/TinkoffCreditSystems/jira-helper/images/features/jira-helper-request_300px.png)
 

--- a/src/README.md
+++ b/src/README.md
@@ -175,6 +175,12 @@ SLA показывает значение в днях.
 
 ![sla-line for control chart](https://raw.githubusercontent.com/TinkoffCreditSystems/jira-helper/images/features/jirahelper_sla_for_controlchart.gif)
 
+## Identity request from Jira-HelpeIdentify request from Jira-Helper
+
+Your administrators of JIRA can identify requests from jira-helper by the special request header
+"chrome-plugin: jira-helper/{version}".
+
+![jira-helper-reques](https://raw.githubusercontent.com/TinkoffCreditSystems/jira-helper/images/features/jira-helper-request_300px.png)
 
 ## Ruler of measuring for control chart
 

--- a/src/shared/defaultHeaders.js
+++ b/src/shared/defaultHeaders.js
@@ -1,0 +1,10 @@
+export const defaultHeaders = defaultHeadersVal => ({
+  init(context, next) {
+    const { headers = {} } = context.state.request;
+    context.state.request.headers = {
+      ...defaultHeadersVal,
+      ...headers,
+    };
+    next();
+  },
+});

--- a/src/shared/jiraApi.js
+++ b/src/shared/jiraApi.js
@@ -22,6 +22,10 @@ const boardEditDataURL = 'greenhopper/1.0/rapidviewconfig/editmodel.json?rapidVi
 const boardEstimationDataURL = 'greenhopper/1.0/rapidviewconfig/estimation.json?rapidViewId=';
 
 const invalidatedProperties = {};
+const headers = {
+  headers: { 'chrome-plugin': `jira-helper/${process.env.PACKAGE_VERSION}` },
+};
+
 const requestJira = request([
   transformUrl({
     baseUrl: `${window.location.origin}/rest/`,
@@ -40,6 +44,7 @@ const getBoardProperties = boardId => {
     url: boardPropertiesUrl(getSearchParam('rapidView')),
     memoryCacheForce,
     type: 'json',
+    ...headers,
   });
 };
 
@@ -56,6 +61,7 @@ export const getBoardProperty = async (boardId, property, params = {}) => {
     memoryCacheForce,
     type: 'json',
     ...params,
+    ...headers,
   }).then(result => result.value);
 };
 
@@ -70,6 +76,7 @@ export const updateBoardProperty = (boardId, property, value, params = {}) => {
     type: 'json',
     payload: value,
     ...params,
+    ...headers,
   });
 };
 
@@ -83,6 +90,7 @@ export const deleteBoardProperty = (boardId, property, params = {}) => {
     httpMethod: 'DELETE',
     type: 'json',
     ...params,
+    ...headers,
   });
 };
 
@@ -91,6 +99,7 @@ export const getBoardEditData = (boardId, params = {}) => {
     url: `${boardEditDataURL}${boardId}`,
     type: 'json',
     ...params,
+    ...headers,
   });
 };
 
@@ -99,6 +108,7 @@ export const getBoardConfiguration = async (boardId, params = {}) => {
     url: boardConfigurationURL(boardId),
     type: 'json',
     ...params,
+    ...headers,
   });
 };
 
@@ -107,6 +117,7 @@ export const getBoardEstimationData = (boardId, params = {}) => {
     url: `${boardEstimationDataURL}${boardId}`,
     type: 'json',
     ...params,
+    ...headers,
   });
 };
 
@@ -115,6 +126,7 @@ export const searchIssues = (jql, params = {}) =>
     url: `api/2/search?jql=${jql}`,
     type: 'json',
     ...params,
+    ...headers,
   });
 
 export const loadNewIssueViewEnabled = (params = {}) =>
@@ -122,6 +134,7 @@ export const loadNewIssueViewEnabled = (params = {}) =>
     url: 'greenhopper/1.0/profile/labs-panel/issue-details-popup',
     type: 'json',
     ...params,
+    ...headers,
   }).then(
     res => res.isEnabled,
     () => false
@@ -131,6 +144,7 @@ export const getAllFields = () =>
   requestJira({
     url: 'api/2/field',
     type: 'json',
+    ...headers,
   });
 
 export const getFlaggedField = async () =>

--- a/src/shared/jiraApi.js
+++ b/src/shared/jiraApi.js
@@ -26,7 +26,7 @@ const invalidatedProperties = {};
 
 const requestJira = request([
   defaultHeaders({
-    'chrome-plugin': `jira-helper/${process.env.PACKAGE_VERSION}`,
+    'browser-plugin': `jira-helper/${process.env.PACKAGE_VERSION}`,
   }),
   transformUrl({
     baseUrl: `${window.location.origin}/rest/`,

--- a/src/shared/jiraApi.js
+++ b/src/shared/jiraApi.js
@@ -11,6 +11,7 @@ import complement from '@tinkoff/utils/function/complement';
 import isNil from '@tinkoff/utils/is/nil';
 import path from '@tinkoff/utils/object/path';
 import pathOr from '@tinkoff/utils/object/pathOr';
+import { defaultHeaders } from './defaultHeaders';
 import { getSearchParam } from '../routing';
 
 export const configVersion = 'v1';
@@ -22,11 +23,11 @@ const boardEditDataURL = 'greenhopper/1.0/rapidviewconfig/editmodel.json?rapidVi
 const boardEstimationDataURL = 'greenhopper/1.0/rapidviewconfig/estimation.json?rapidViewId=';
 
 const invalidatedProperties = {};
-const headers = {
-  headers: { 'chrome-plugin': `jira-helper/${process.env.PACKAGE_VERSION}` },
-};
 
 const requestJira = request([
+  defaultHeaders({
+    'chrome-plugin': `jira-helper/${process.env.PACKAGE_VERSION}`,
+  }),
   transformUrl({
     baseUrl: `${window.location.origin}/rest/`,
   }),
@@ -44,7 +45,6 @@ const getBoardProperties = boardId => {
     url: boardPropertiesUrl(getSearchParam('rapidView')),
     memoryCacheForce,
     type: 'json',
-    ...headers,
   });
 };
 
@@ -61,7 +61,6 @@ export const getBoardProperty = async (boardId, property, params = {}) => {
     memoryCacheForce,
     type: 'json',
     ...params,
-    ...headers,
   }).then(result => result.value);
 };
 
@@ -76,7 +75,6 @@ export const updateBoardProperty = (boardId, property, value, params = {}) => {
     type: 'json',
     payload: value,
     ...params,
-    ...headers,
   });
 };
 
@@ -90,7 +88,6 @@ export const deleteBoardProperty = (boardId, property, params = {}) => {
     httpMethod: 'DELETE',
     type: 'json',
     ...params,
-    ...headers,
   });
 };
 
@@ -99,7 +96,6 @@ export const getBoardEditData = (boardId, params = {}) => {
     url: `${boardEditDataURL}${boardId}`,
     type: 'json',
     ...params,
-    ...headers,
   });
 };
 
@@ -108,7 +104,6 @@ export const getBoardConfiguration = async (boardId, params = {}) => {
     url: boardConfigurationURL(boardId),
     type: 'json',
     ...params,
-    ...headers,
   });
 };
 
@@ -117,7 +112,6 @@ export const getBoardEstimationData = (boardId, params = {}) => {
     url: `${boardEstimationDataURL}${boardId}`,
     type: 'json',
     ...params,
-    ...headers,
   });
 };
 
@@ -126,7 +120,6 @@ export const searchIssues = (jql, params = {}) =>
     url: `api/2/search?jql=${jql}`,
     type: 'json',
     ...params,
-    ...headers,
   });
 
 export const loadNewIssueViewEnabled = (params = {}) =>
@@ -134,7 +127,6 @@ export const loadNewIssueViewEnabled = (params = {}) =>
     url: 'greenhopper/1.0/profile/labs-panel/issue-details-popup',
     type: 'json',
     ...params,
-    ...headers,
   }).then(
     res => res.isEnabled,
     () => false
@@ -144,7 +136,6 @@ export const getAllFields = () =>
   requestJira({
     url: 'api/2/field',
     type: 'json',
-    ...headers,
   });
 
 export const getFlaggedField = async () =>

--- a/webpack/webpack.common.config.js
+++ b/webpack/webpack.common.config.js
@@ -1,9 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
+const pcg = require('../package.json');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const version = process.env.PACKAGE_VERSION || pcg.version;
 
 module.exports = {
   stats: 'errors-only',
@@ -98,16 +101,14 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.PACKAGE_VERSION': JSON.stringify(version),
     }),
     {
       apply(compiler) {
         compiler.hooks.afterEmit.tap('SetVersionPlugin', () => {
-          // eslint-disable-next-line global-require
-          const pcg = require('../package.json');
-          // eslint-disable-next-line global-require
           const manifest = require('../dist/manifest.json');
 
-          manifest.version = pcg.version;
+          manifest.version = version;
 
           fs.promises.writeFile(path.resolve(__dirname, '../dist/manifest.json'), JSON.stringify(manifest, null, 2));
         });


### PR DESCRIPTION
JIRA platform administrators very much asked to add a header to the request from jira-helper so that you can evaluate the load this plug-in generates on the system