### PR TITLE
Добавляет цвет ошибки на внутреннюю головную часть свимлэйна

### DIFF
--- a/src/swimlane/SwimlaneLimits.js
+++ b/src/swimlane/SwimlaneLimits.js
@@ -68,10 +68,14 @@ export default class extends PageModification {
       swimlanesIssuesCount[swimlaneId] = numberIssues;
 
       const swimlaneDescription = swimlane.querySelector('.ghx-description');
+      const innerSwimlaneHeader = swimlane.querySelector('.ghx-swimlane-header');
 
       if (numberIssues > limit) {
         swimlane.style.backgroundColor = '#ff5630';
         swimlaneDescription.style.color = '#ffd700';
+
+        // Some JIRA-versions has white backgroundColor on swimlane header, f.e. v8.8.1
+        innerSwimlaneHeader.style.backgroundColor = '#ff5630';
       }
 
       this.renderSwimlaneHeaderLimit(numberIssues, limit, swimlaneHeader);


### PR DESCRIPTION
На некоторых версиях JIRA есть стиль на белый фон для  `.ghx-swimlane-header`, что вызывает белый цвет при необходимом цвете ошибки в случае превышения лимит на дорожку.
Проблема не воспроизводится на Cloud Jira, но например на версии v8.8.1 воспроизводится стабильно. Оставил комментарий по этому случаю. 